### PR TITLE
Fix no data on UART problem

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -138,7 +138,7 @@ void Error_Handler(void);
 #define HEAT_COOL_2_Pin GPIO_PIN_9
 #define HEAT_COOL_2_GPIO_Port GPIOB
 /* USER CODE BEGIN Private defines */
-#define ADC_CHANNELS 8
+#define ADC_CHANNELS 14
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus


### PR DESCRIPTION
The ADC_CHANNELS macro in main.h was set to 8 channels instead of 14.